### PR TITLE
Fix speech generation to focus on topics instead of association words

### DIFF
--- a/src/app/api/generate-speech/route.ts
+++ b/src/app/api/generate-speech/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { GoogleGenerativeAI } from '@google/generative-ai'
+
+// Move API key to server-only environment variable
+const API_KEY = process.env.GEMINI_API_KEY || process.env.NEXT_PUBLIC_GEMINI_API_KEY || ''
+
+// Type definitions
+interface SpeechResponse {
+  speech: {
+    opening: string
+    body: string[]
+    closing: string
+  }
+  tips: string[]
+  isFromCache?: boolean
+}
+
+interface RequestBody {
+  topic: string
+  associations: string
+}
+
+// Model configuration
+const genAI = new GoogleGenerativeAI(API_KEY)
+const model = genAI.getGenerativeModel({ 
+  model: 'gemini-2.0-flash-lite',
+  generationConfig: {
+    temperature: 0.85,
+    maxOutputTokens: 2000,
+    responseMimeType: 'application/json'
+  }
+})
+
+// Validation function
+function validateRequestBody(body: any): body is RequestBody {
+  return typeof body.topic === 'string' && 
+         typeof body.associations === 'string' &&
+         body.topic.length > 0 &&
+         body.associations.length > 0
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse<SpeechResponse | { error: string }>> {
+  try {
+    const body = await request.json()
+    
+    // Request validation
+    if (!validateRequestBody(body)) {
+      return NextResponse.json(
+        { error: 'お題と連想ワードを指定してください' },
+        { status: 400 }
+      )
+    }
+
+    const { topic, associations } = body
+
+    const prompt = `
+あなたは優秀なスピーチライターです。
+与えられたお題について、1-2分程度の短いスピーチ原稿を作成してください。
+
+与えられた情報:
+- スピーチのお題: "${topic}"
+- 連想ワード（ヒント）: ${associations}
+
+重要な注意事項:
+- スピーチは「${topic}」についてのスピーチです
+- 連想ワードは発想のヒントとして参考にしてください
+- 連想ワードの中から特定の言葉を選んで話す必要はありません
+- 「${topic}」から自由に発想を広げてスピーチを作成してください
+
+以下の構成でスピーチを作成してください:
+
+1. 導入（opening）: 
+   - 聴衆の注意を引く開始
+   - 「${topic}」についての導入
+   - 50-80文字程度
+
+2. 本文（body）: 
+   - 3つの段落で構成
+   - 各段落は80-120文字程度
+   - 個人的な経験や具体例を含める
+   - 連想ワードからインスピレーションを得た内容を含めても良い
+   - 聴衆が共感できる内容
+
+3. 締めくくり（closing）:
+   - 印象的な結び
+   - 聴衆への問いかけや行動の促し
+   - 50-80文字程度
+
+4. スピーチのポイント（tips）:
+   - このスピーチを効果的にするための3つのアドバイス
+   - 各20-40文字程度
+
+以下のJSON形式で出力してください:
+{
+  "speech": {
+    "opening": "導入文",
+    "body": ["第1段落", "第2段落", "第3段落"],
+    "closing": "締めくくり文"
+  },
+  "tips": ["ポイント1", "ポイント2", "ポイント3"]
+}
+
+注意事項:
+- 自然で話しやすい日本語を使用
+- 堅すぎず、親しみやすいトーン
+- 「${topic}」を中心にスピーチを組み立てる
+- 1-2分で話せる長さ（全体で300-500文字程度）
+`
+
+    try {
+      const result = await model.generateContent(prompt)
+      const response = result.response
+      
+      // Parse JSON response
+      const responseData = JSON.parse(response.text()) as SpeechResponse
+      
+      // Validation
+      if (!responseData.speech || !responseData.tips) {
+        throw new Error('Invalid response format')
+      }
+      
+      return NextResponse.json(responseData)
+      
+    } catch (apiError) {
+      console.error('Speech generation failed:', apiError)
+      
+      // Fallback speech
+      const fallbackSpeech: SpeechResponse = {
+        speech: {
+          opening: `皆さん、今日は「${topic}」についてお話しさせていただきます。`,
+          body: [
+            `「${topic}」というテーマを聞いて、私はある思い出が鮮明に蘇ってきました。それは、私の人生観を変えた一つの出来事でした。`,
+            `誰もが「${topic}」について、それぞれの経験や想いを持っているはずです。私にとってそれは、日常の中で見過ごしていた大切なものに気づかせてくれる機会でした。`,
+            `今振り返ると、「${topic}」は私たちの生活のあちこちに存在しています。大切なのは、それに気づき、向き合う勇気を持つことかもしれません。`
+          ],
+          closing: `皆さんも、ご自身の「${topic}」について、もう一度考えてみませんか。きっと新しい発見があるはずです。`,
+        },
+        tips: [
+          '個人的な体験を具体的に語る',
+          '聴衆が共感できるエピソードを選ぶ',
+          '最後は行動への呼びかけで締める'
+        ],
+        isFromCache: true
+      }
+      
+      return NextResponse.json(fallbackSpeech)
+    }
+  } catch (error) {
+    console.error('Route handler error:', error)
+    return NextResponse.json(
+      { error: 'スピーチの生成に失敗しました' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/examples/page.tsx
+++ b/src/app/examples/page.tsx
@@ -1,0 +1,363 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { motion } from 'framer-motion'
+import { ArrowLeft, Sparkles, MessageSquare, ArrowRight, Lightbulb, AlertCircle, Loader2, RefreshCw } from 'lucide-react'
+import Link from 'next/link'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Topic } from '@/types'
+import { generateSpeech, SpeechData } from '@/lib/api-client'
+
+interface GeneratedSpeech extends SpeechData {
+  index: number
+  loading?: boolean
+  error?: string
+}
+
+export default function ExamplesPage() {
+  const [topics, setTopics] = useState<Topic[]>([])
+  const [speeches, setSpeeches] = useState<GeneratedSpeech[]>([])
+  const [loading, setLoading] = useState(true)
+  const [generatingAll, setGeneratingAll] = useState(false)
+
+  useEffect(() => {
+    // Load topics from session storage
+    const loadTopics = () => {
+      try {
+        const cachedTopics = sessionStorage.getItem('topics')
+        if (cachedTopics) {
+          const parsedTopics = JSON.parse(cachedTopics) as Topic[]
+          // Filter only topics that have associations
+          const topicsWithAssociations = parsedTopics.filter(t => t.associations)
+          setTopics(topicsWithAssociations)
+        }
+      } catch (err) {
+        console.error('Failed to load topics:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadTopics()
+  }, [])
+
+  // Generate speech for the topic
+  const generateSpeechForTopic = async (topic: Topic, index: number): Promise<GeneratedSpeech> => {
+    try {
+      const speechData = await generateSpeech(
+        topic.text,
+        topic.associations!
+      )
+      return { ...speechData, index, loading: false }
+    } catch (error) {
+      return { 
+        index, 
+        loading: false, 
+        error: 'スピーチの生成に失敗しました',
+        speech: { opening: '', body: [], closing: '' },
+        tips: []
+      }
+    }
+  }
+
+  // Generate speeches for all topics
+  const generateSpeeches = async () => {
+    const topicsWithAssociations = topics.filter(t => t.associations)
+    if (topicsWithAssociations.length === 0) return
+
+    setGeneratingAll(true)
+    // Generate one speech per topic
+    setSpeeches(topicsWithAssociations.map((_, index) => ({ 
+      index, 
+      loading: true, 
+      speech: { opening: '', body: [], closing: '' }, 
+      tips: [] 
+    })))
+
+    // Generate speeches in parallel
+    const promises = topicsWithAssociations.map((topic, index) => generateSpeechForTopic(topic, index))
+    const results = await Promise.all(promises)
+    
+    setSpeeches(results)
+    setGeneratingAll(false)
+  }
+
+  // Auto-generate speeches when topics are loaded
+  useEffect(() => {
+    if (topics.length > 0) {
+      generateSpeeches()
+    }
+  }, [topics])
+
+  // Regenerate a specific speech
+  const regenerateSpeech = async (index: number) => {
+    const topicsWithAssociations = topics.filter(t => t.associations)
+    if (index >= topicsWithAssociations.length) return
+
+    const topic = topicsWithAssociations[index]
+
+    setSpeeches(prev => prev.map(s => 
+      s.index === index ? { ...s, loading: true } : s
+    ))
+
+    const newSpeech = await generateSpeechForTopic(topic, index)
+    
+    setSpeeches(prev => prev.map(s => 
+      s.index === index ? newSpeech : s
+    ))
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[#FAFBFC] flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#0052CC] mx-auto"></div>
+          <p className="mt-4 text-[#6B778C]">読み込み中...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (topics.length === 0) {
+    return (
+      <div className="min-h-screen bg-[#FAFBFC]">
+        <div className="max-w-[480px] mx-auto px-4 py-8">
+          <Link href="/">
+            <Button variant="subtle" size="sm" className="mb-4">
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              ホームに戻る
+            </Button>
+          </Link>
+          
+          <Card>
+            <CardContent className="py-12 text-center">
+              <AlertCircle className="w-12 h-12 text-[#6B778C] mx-auto mb-3" />
+              <p className="text-[#6B778C]">
+                まだスピーチ例を表示できるお題がありません。
+              </p>
+              <p className="text-sm text-[#6B778C] mt-2">
+                ホームに戻って、お題を生成し、連想ワードを作成してください。
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+
+  const topicsWithAssociations = topics.filter(t => t.associations)
+
+  return (
+    <div className="min-h-screen bg-[#FAFBFC]">
+      <div className="max-w-[800px] mx-auto px-4 py-8">
+        <motion.header 
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mb-8"
+        >
+          <Link href="/">
+            <Button variant="subtle" size="sm" className="mb-4">
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              ホームに戻る
+            </Button>
+          </Link>
+          
+          <div className="flex items-center gap-2 mb-2">
+            <Lightbulb className="w-6 h-6 text-[#FFAB00]" />
+            <h1 className="text-2xl font-bold text-[#172B4D]">
+              スピーチ例
+            </h1>
+          </div>
+          <p className="text-sm text-[#6B778C] leading-5">
+            生成された各お題についてスピーチ例を表示します
+          </p>
+        </motion.header>
+
+
+        {/* Regenerate All Button */}
+        <div className="mb-6 text-right">
+          <Button
+            variant="subtle"
+            size="sm"
+            onClick={generateSpeeches}
+            disabled={generatingAll}
+          >
+            <RefreshCw className="w-4 h-4 mr-2" />
+            全て再生成
+          </Button>
+        </div>
+
+        {/* All Speeches Loading State */}
+        {generatingAll && (
+          <Card className="mb-6">
+            <CardContent className="py-12 text-center">
+              <Loader2 className="w-8 h-8 animate-spin text-[#0052CC] mx-auto mb-3" />
+              <p className="text-[#6B778C]">スピーチ例を生成中...</p>
+              <p className="text-sm text-[#6B778C] mt-2">各お題についてスピーチを作成しています</p>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Generated Speeches */}
+        <div className="space-y-6">
+          {speeches.map((speech, index) => (
+            <motion.div
+              key={`speech-${speech.index}`}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: index * 0.1 }}
+            >
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center justify-between">
+                    <span className="flex items-center gap-2 text-lg">
+                      <Sparkles className="w-5 h-5 text-[#FFAB00]" />
+                      「{topicsWithAssociations[speech.index]?.text}」のスピーチ例
+                    </span>
+                    <Button
+                      variant="subtle"
+                      size="sm"
+                      onClick={() => regenerateSpeech(speech.index)}
+                      disabled={speech.loading}
+                    >
+                      {speech.loading ? (
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                      ) : (
+                        <>
+                          <RefreshCw className="w-4 h-4 mr-2" />
+                          再生成
+                        </>
+                      )}
+                    </Button>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {/* Show associations for this topic */}
+                  {topicsWithAssociations[speech.index]?.associations && !speech.loading && !speech.error && (
+                    <div className="bg-[#F4F5F7] p-3 rounded-lg">
+                      <p className="text-xs text-[#6B778C] font-medium mb-2">連想ワード:</p>
+                      <div className="flex flex-wrap items-center gap-2">
+                        {topicsWithAssociations[speech.index].associations!.split(' → ').map((word, idx, arr) => (
+                          <div key={idx} className="flex items-center gap-2">
+                            <Badge variant="subtle" size="sm">
+                              {word.trim()}
+                            </Badge>
+                            {idx < arr.length - 1 && (
+                              <ArrowRight className="w-3 h-3 text-[#6B778C]" />
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  
+                  {speech.loading ? (
+                    <div className="py-8 text-center">
+                      <Loader2 className="w-6 h-6 animate-spin text-[#0052CC] mx-auto mb-2" />
+                      <p className="text-sm text-[#6B778C]">生成中...</p>
+                    </div>
+                  ) : speech.error ? (
+                    <div className="py-8 text-center">
+                      <AlertCircle className="w-6 h-6 text-[#DE350B] mx-auto mb-2" />
+                      <p className="text-sm text-[#6B778C]">{speech.error}</p>
+                    </div>
+                  ) : (
+                    <>
+                      {/* Speech Content */}
+                      <div className="space-y-4">
+                        <div>
+                          <h4 className="text-sm font-semibold text-[#172B4D] mb-2">導入</h4>
+                          <p className="text-sm text-[#172B4D] leading-6 bg-[#DEEBFF] p-3 rounded">
+                            {speech.speech.opening}
+                          </p>
+                        </div>
+
+                        <div>
+                          <h4 className="text-sm font-semibold text-[#172B4D] mb-2">本文</h4>
+                          <div className="space-y-2">
+                            {speech.speech.body.map((paragraph, idx) => (
+                              <p key={idx} className="text-sm text-[#172B4D] leading-6">
+                                {paragraph}
+                              </p>
+                            ))}
+                          </div>
+                        </div>
+
+                        <div>
+                          <h4 className="text-sm font-semibold text-[#172B4D] mb-2">締めくくり</h4>
+                          <p className="text-sm text-[#172B4D] leading-6 bg-[#E3FCEF] p-3 rounded">
+                            {speech.speech.closing}
+                          </p>
+                        </div>
+                      </div>
+
+                      {/* Tips */}
+                      <div className="border-t pt-4">
+                        <h4 className="text-sm font-semibold text-[#172B4D] mb-2 flex items-center gap-2">
+                          <Lightbulb className="w-4 h-4 text-[#FFAB00]" />
+                          このスピーチのポイント
+                        </h4>
+                        <ul className="space-y-1">
+                          {speech.tips.map((tip, idx) => (
+                            <li key={idx} className="text-sm text-[#6B778C] flex items-start gap-2">
+                              <span className="text-[#36B37E] mt-0.5">•</span>
+                              <span>{tip}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    </>
+                  )}
+                </CardContent>
+              </Card>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* General Tips */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.4 }}
+          className="mt-8"
+        >
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Lightbulb className="w-5 h-5 text-[#FFAB00]" />
+                スピーチ作成のコツ
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                <div>
+                  <h4 className="font-medium text-[#172B4D] mb-2">1. お題ごとのスピーチ例</h4>
+                  <p className="text-sm text-[#6B778C] leading-5">
+                    各お題について1つずつスピーチ例が生成されます。
+                    連想ワードをヒントに、お題から自由に発想を広げた内容になっています。
+                  </p>
+                </div>
+                <div>
+                  <h4 className="font-medium text-[#172B4D] mb-2">2. スピーチのカスタマイズ</h4>
+                  <p className="text-sm text-[#6B778C] leading-5">
+                    生成されたスピーチ例をベースに、
+                    自分の体験や考えを加えてオリジナルのスピーチに仕上げましょう。
+                  </p>
+                </div>
+                <div>
+                  <h4 className="font-medium text-[#172B4D] mb-2">3. 連想ワードの活用</h4>
+                  <p className="text-sm text-[#6B778C] leading-5">
+                    各スピーチに表示されている連想ワードは、
+                    スピーチ作成のヒントやインスピレーションとして活用できます。
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </motion.div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -141,6 +141,10 @@ export default function AboutSection() {
               <span className="font-semibold text-[#0052CC]">3.</span>
               表示された連想ワードをヒントにスピーチに挑戦！
             </li>
+            <li className="flex gap-2">
+              <span className="font-semibold text-[#0052CC]">4.</span>
+              「スピーチ例を見る」で実際の構成を参考にできます
+            </li>
           </ol>
         </div>
       </CardContent>

--- a/src/components/TopicsList.tsx
+++ b/src/components/TopicsList.tsx
@@ -2,11 +2,13 @@
 
 import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { MessageSquare, CheckCircle2, ChevronDown, Loader2, ArrowRight } from 'lucide-react'
+import { MessageSquare, CheckCircle2, ChevronDown, Loader2, ArrowRight, Lightbulb } from 'lucide-react'
+import Link from 'next/link'
 import { Topic } from '@/types'
 import { generateAssociations } from '@/lib/api-client'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
 interface TopicsListProps {
@@ -189,10 +191,22 @@ export default function TopicsList({ topics, hasGenerated = false, onTopicsUpdat
           ))}
         </div>
         
-        <div className="mt-4 p-3 bg-[#F4F5F7] rounded">
-          <p className="text-xs text-[#6B778C] text-center">
-            お題をクリックすると連想ワードが表示されます
-          </p>
+        <div className="mt-4 space-y-3">
+          <div className="p-3 bg-[#F4F5F7] rounded">
+            <p className="text-xs text-[#6B778C] text-center">
+              お題をクリックすると連想ワードが表示されます
+            </p>
+          </div>
+          
+          {/* Show examples button if any topic has associations */}
+          {topics.some(t => t.associations) && (
+            <Link href="/examples" className="block">
+              <Button variant="primary" className="w-full">
+                <Lightbulb className="w-4 h-4 mr-2" />
+                このお題でスピーチ例を見る
+              </Button>
+            </Link>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -45,3 +45,38 @@ export async function generateAssociations(topic: string): Promise<string> {
     throw error
   }
 }
+
+export interface SpeechData {
+  speech: {
+    opening: string
+    body: string[]
+    closing: string
+  }
+  tips: string[]
+}
+
+export async function generateSpeech(
+  topic: string, 
+  associations: string
+): Promise<SpeechData> {
+  try {
+    const response = await fetch('/api/generate-speech', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ topic, associations }),
+    })
+
+    if (!response.ok) {
+      const error = await response.json()
+      throw new Error(error.error || 'Failed to generate speech')
+    }
+
+    const data = await response.json()
+    return data
+  } catch (error) {
+    console.error('Error generating speech:', error)
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary
- Fixed fundamental issue where speeches were generated based on association words instead of topics
- Updated examples page to show one speech per topic instead of multiple speeches for a single topic
- Clarified that association words are hints/inspiration, not the speech subject

## Changes Made

### API Updates
- Removed `selectedWord` parameter from `/api/generate-speech` endpoint
- Updated prompt to emphasize speeches should be about the topic itself
- Fixed fallback speech to be topic-focused

### UI Updates
- Changed examples page from showing 3 speeches for 1 topic to 1 speech per topic
- Added association words display within each speech card as hints
- Updated all UI text to reflect the correct approach
- Modified tips section to explain the new one-example-per-topic approach

### Client Library
- Updated `generateSpeech` function to remove `selectedWord` parameter
- Now only requires `topic` and `associations` parameters

## Test Plan
- [x] Generate topics and associations
- [x] Navigate to examples page
- [x] Verify one speech is generated per topic
- [x] Verify speeches are about the topic, not association words
- [x] Test regeneration of individual speeches
- [x] Test "regenerate all" functionality

🤖 Generated with [Claude Code](https://claude.ai/code)