### PR TITLE
Improve UX: Generate speeches without associations and change default participants to 1

### DIFF
--- a/src/app/api/generate-speech/route.ts
+++ b/src/app/api/generate-speech/route.ts
@@ -35,8 +35,7 @@ const model = genAI.getGenerativeModel({
 function validateRequestBody(body: any): body is RequestBody {
   return typeof body.topic === 'string' && 
          typeof body.associations === 'string' &&
-         body.topic.length > 0 &&
-         body.associations.length > 0
+         body.topic.length > 0
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse<SpeechResponse | { error: string }>> {
@@ -46,7 +45,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<SpeechRes
     // Request validation
     if (!validateRequestBody(body)) {
       return NextResponse.json(
-        { error: 'お題と連想ワードを指定してください' },
+        { error: 'お題を指定してください' },
         { status: 400 }
       )
     }
@@ -59,12 +58,12 @@ export async function POST(request: NextRequest): Promise<NextResponse<SpeechRes
 
 与えられた情報:
 - スピーチのお題: "${topic}"
-- 連想ワード（ヒント）: ${associations}
+${associations ? `- 連想ワード（ヒント）: ${associations}` : ''}
 
 重要な注意事項:
 - スピーチは「${topic}」についてのスピーチです
-- 連想ワードは発想のヒントとして参考にしてください
-- 連想ワードの中から特定の言葉を選んで話す必要はありません
+${associations ? `- 連想ワードは発想のヒントとして参考にしてください
+- 連想ワードの中から特定の言葉を選んで話す必要はありません` : ''}
 - 「${topic}」から自由に発想を広げてスピーチを作成してください
 
 以下の構成でスピーチを作成してください:
@@ -78,7 +77,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<SpeechRes
    - 3つの段落で構成
    - 各段落は80-120文字程度
    - 個人的な経験や具体例を含める
-   - 連想ワードからインスピレーションを得た内容を含めても良い
+${associations ? '   - 連想ワードからインスピレーションを得た内容を含めても良い' : ''}
    - 聴衆が共感できる内容
 
 3. 締めくくり（closing）:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ import { Topic } from '@/types'
 import { generateTopics } from '@/lib/api-client'
 
 export default function Home() {
-  const [participants, setParticipants] = useState<number>(5)
+  const [participants, setParticipants] = useState<number>(1)
   const [topics, setTopics] = useState<Topic[]>([])
   const [isGenerating, setIsGenerating] = useState(false)
   const [hasGenerated, setHasGenerated] = useState(false)

--- a/src/components/TopicsList.tsx
+++ b/src/components/TopicsList.tsx
@@ -198,12 +198,12 @@ export default function TopicsList({ topics, hasGenerated = false, onTopicsUpdat
             </p>
           </div>
           
-          {/* Show examples button if any topic has associations */}
-          {topics.some(t => t.associations) && (
+          {/* Show examples button if topics exist */}
+          {topics.length > 0 && (
             <Link href="/examples" className="block">
               <Button variant="primary" className="w-full">
                 <Lightbulb className="w-4 h-4 mr-2" />
-                このお題でスピーチ例を見る
+                スピーチ例を見る
               </Button>
             </Link>
           )}


### PR DESCRIPTION
## Summary
- Allow speech generation from topics alone without requiring associations
- Show all topics on examples page immediately after generation
- Change default number of participants from 5 to 1
- Improve loading states and user feedback

## Problem
Users had to go through multiple steps before seeing speech examples:
1. Generate topics
2. Click each topic to generate associations
3. Only then could they see examples

This created unnecessary friction, especially since associations are just optional hints.

## Solution

### 1. Generate speeches from topics alone
- Modified API to accept empty association strings
- Updated prompts to handle both cases (with/without associations)
- Removed validation that required associations

### 2. Immediate access to examples
- "スピーチ例を見る" button appears right after generating topics
- All topics shown on examples page, not just those with associations
- Speeches generated using topic alone if no associations exist

### 3. Better loading experience  
- All speech cards displayed immediately with loading states
- Each speech updates independently as generated
- Removed confusing "連想ワードを生成してください" error

### 4. Default participants = 1
- More suitable for individual practice
- Reduces initial friction
- Users can still increase for group practice

## Technical Changes

### API Route (`/api/generate-speech`)
- Removed association requirement from validation
- Conditional prompt formatting based on association presence
- Gracefully handles empty association strings

### Examples Page
- Removed `topicsWithAssociations` filter
- Pass empty string for associations if none exist
- Show all topics immediately

### Topics List Component
- Show examples button based on topic count, not associations
- Updated button text to remove "このお題で"

## Test Plan
- [x] Generate topics without associations
- [x] Navigate to examples page immediately
- [x] Verify speeches generate from topics alone
- [x] Test with associations added later
- [x] Verify loading states appear for all topics
- [x] Check default participant count is 1
- [x] Test regeneration functionality

## User Impact
✅ Faster time to first speech example
✅ Less confusion about required steps
✅ More flexible usage patterns
✅ Better suited for individual practice

🤖 Generated with [Claude Code](https://claude.ai/code)